### PR TITLE
Add Clearart to Home Spotlight

### DIFF
--- a/1080i/Includes_Home.xml
+++ b/1080i/Includes_Home.xml
@@ -92,6 +92,17 @@
                                 <effect type="slide" end="0,-20" time="60" tween="sine" />
                                 <effect type="slide" end="0,20" time="180" tween="sine" delay="80" />
                             </animation>
+                            <control type="image">
+                                <right>85</right>
+                                <bottom>400</bottom>
+                                <height>350</height>
+                                <width>700</width>
+                                <texture background="true">$VAR[Image_ClearArt]</texture>
+                                <aspectratio align="right" aligny="bottom" scalediffuse="false">keep</aspectratio>
+                                <bordersize>15</bordersize>
+                                <visible>!Control.HasFocus(3992)</visible>
+                                <include>Animation_FadeInOut_Common</include>
+                            </control>
                             <include>skinshortcuts-template-widgets</include>
                             <control type="group">
                                 <visible>String.IsEqual(Container(3700).ListItemAbsolute(0).Property(list),Weather) + Weather.IsFetched</visible>
@@ -394,7 +405,7 @@
                 <control type="grouplist">
                     <top>5</top>
                     <left>100</left>
-                    <right>580</right>
+                    <right>800</right>
                     <bottom>60</bottom>
                     <orientation>vertical</orientation>
                     <usecontrolcoords>true</usecontrolcoords>

--- a/1080i/Includes_Viewtype.xml
+++ b/1080i/Includes_Viewtype.xml
@@ -40,6 +40,7 @@
                             <aspectratio align="right" aligny="bottom" scalediffuse="false">keep</aspectratio>
                             <bordersize>15</bordersize>
                             <visible>Control.IsVisible(52) | Control.IsVisible(53) | Control.IsVisible(54) | [Control.IsVisible(56) + [!Container.Content(years) | !Window.IsVisible(MyMusicNav.xml)]]</visible>
+                            <include>Animation_FadeInOut_Common</include>
                         </control>
                         <control type="image">
                             <right>-15</right>


### PR DESCRIPTION
So, I started this in response to #75, but just have a weird bug where it'll show even when there's no "spotlight"...

![ezgif com-optimize](https://user-images.githubusercontent.com/2319508/77784755-4a855700-7018-11ea-80f9-222959ac4136.gif)

Hopefully we can get that working :wink:
