### PR TITLE
Fix Information Screen Buttons

### DIFF
--- a/1080i/DialogAddonInfo.xml
+++ b/1080i/DialogAddonInfo.xml
@@ -52,9 +52,13 @@
                             <param name="height" value="auto" />
                         </include>
                     </control>
-                    <include content="Info_Button_Grouplist">
+                </include>
+                <include content="Info_Button_Grouplist">
                         <param name="includebuttons" value="Info_Buttons_Addon" />
-                    </include>
+                        <left>80</left>
+                        <top>-45</top>
+                        <bottom>0</bottom>
+                        <height>80</height>
                 </include>
                 <include content="Info_Widget_Poster">
                     <param name="includecondition" value="true" />

--- a/1080i/Includes_DialogVideoInfo.xml
+++ b/1080i/Includes_DialogVideoInfo.xml
@@ -64,10 +64,15 @@
                 <include content="DialogVideoInfo_WidgetGroupList">
                     <include content="DialogVideoInfo_MainInfo">
                         <include content="View_Info_Grouplist">
-                            <height>285</height>
+                            <height>400</height>
                         </include>
-                        <include>Info_Button_Grouplist</include>
                     </include>
+					<include content="Info_Button_Grouplist">
+						<left>80</left>
+						<top>-45</top>
+						<bottom>0</bottom>
+						<height>80</height>
+					</include>
                     <include content="DialogVideoInfo_Widget_Details">
                         <param name="id" value="7100" />
                         <param name="uid" value="2003" />

--- a/1080i/Includes_DialogVideoInfo.xml
+++ b/1080i/Includes_DialogVideoInfo.xml
@@ -67,12 +67,12 @@
                             <height>400</height>
                         </include>
                     </include>
-					<include content="Info_Button_Grouplist">
-						<left>80</left>
-						<top>-45</top>
-						<bottom>0</bottom>
-						<height>80</height>
-					</include>
+                    <include content="Info_Button_Grouplist">
+                        <left>80</left>
+                        <top>-45</top>
+                        <bottom>0</bottom>
+                        <height>80</height>
+                    </include>
                     <include content="DialogVideoInfo_Widget_Details">
                         <param name="id" value="7100" />
                         <param name="uid" value="2003" />


### PR DESCRIPTION
Fixes Information screen buttons so you can click on them, and adds an extra line to the info screen's description.

Probably not the best way since you have to do it in 2 locations, but if you change the left, top, height properties in Defs_ButtonList it breaks them in the widgets.