### PR TITLE
Bundle of Suggested Additions

### DIFF
--- a/1080i/Font.xml
+++ b/1080i/Font.xml
@@ -277,5 +277,281 @@
         <include>VideoLyrics_Fonts</include>
 
     </fontset>
+    <fontset id="Slightly Larger" unicode="true">
+
+        <!-- Standard Fonts -->
+        <font>
+            <name>font_medium</name>
+            <filename>RobotoCondensed-Regular.ttf</filename>
+            <size>42</size>
+        </font>
+        <font>
+            <name>font_medium_bold</name>
+            <filename>RobotoCondensed-Bold.ttf</filename>
+            <size>42</size>
+        </font>
+        <font>
+            <name>font_small</name>
+            <filename>RobotoCondensed-Regular.ttf</filename>
+            <size>33</size>
+        </font>
+        <font>
+            <name>font_small_mono</name>
+            <filename>RobotoMono-Bold.ttf</filename>
+            <size>29</size>
+            <aspect>0.8</aspect>
+        </font>
+        <font>
+            <name>font_small_bold</name>
+            <filename>RobotoCondensed-Bold.ttf</filename>
+            <size>33</size>
+        </font>
+        <font>
+            <name>font_tiny</name>
+            <filename>RobotoCondensed-Regular.ttf</filename>
+            <size>29</size>
+        </font>
+        <font>
+            <name>font_tiny_bold</name>
+            <filename>RobotoCondensed-Bold.ttf</filename>
+            <size>29</size>
+        </font>
+        <font>
+            <name>font_button</name>
+            <style>uppercase</style>
+            <filename>RobotoCondensed-Regular-Caps.ttf</filename>
+            <size>26</size>
+        </font>
+        <font>
+            <name>font_statusbar</name>
+            <filename>RobotoCondensed-Regular.ttf</filename>
+            <size>24</size>
+        </font>
+        <font>
+            <name>font_fps</name>
+            <filename>RobotoCondensed-Regular.ttf</filename>
+            <size>18</size>
+        </font>
+        <font>
+            <name>font_osd_lang</name>
+            <filename>RobotoCondensed-Regular.ttf</filename>
+            <size>12</size>
+        </font>
+        <font>
+            <name>font_statusbar_bold</name>
+            <filename>RobotoCondensed-Bold.ttf</filename>
+            <size>26</size>
+        </font>
+        <font>
+            <name>font_info_buttons</name>
+            <filename>RobotoCondensed-Bold-Caps.ttf</filename>
+            <size>22</size>
+            <style>uppercase</style>
+        </font>
+        <font>
+            <name>font_unwatched</name>
+            <filename>RobotoCondensed-Bold.ttf</filename>
+            <size>18</size>
+        </font>
+        <font>
+            <name>font_mini</name>
+            <style>uppercase</style>
+            <filename>RobotoCondensed-Regular-Caps.ttf</filename>
+            <size>22</size>
+        </font>
+
+        <!-- Plot Font -->
+        <font>
+            <name>font_plotbox</name>
+            <filename>Roboto-Regular-Linespacing.ttf</filename>
+            <linespacing>1</linespacing>
+            <size>32</size>
+            <aspect>0.9</aspect>
+        </font>
+        <font>
+            <name>font_plotbox_small</name>
+            <filename>Roboto-Regular-Linespacing.ttf</filename>
+            <linespacing>1</linespacing>
+            <size>28</size>
+            <aspect>0.9</aspect>
+        </font>
+        <font>
+            <name>font_weather_small</name>
+            <filename>Roboto-Regular-Linespacing.ttf</filename>
+            <size>29</size>
+            <aspect>0.9</aspect>
+        </font>
+        <font>
+            <name>font_overlay_plotbox</name>
+            <filename>Roboto-Regular-Linespacing.ttf</filename>
+            <linespacing>1.45</linespacing>
+            <aspect>0.9</aspect>
+            <size>52</size>
+        </font>
+        <font>
+            <name>font_info_display</name>
+            <style>bold</style>
+            <filename>RobotoCondensed-Bold.ttf</filename>
+            <size>64</size>
+        </font>
+
+        <!-- Music visualisation scrolling text -->
+        <font>
+            <name>font_musicvis_biggest</name>
+            <filename>RobotoCondensed-Light.ttf</filename>
+            <size>230</size>
+        </font>
+        <font>
+            <name>font_musicvis_bigger</name>
+            <filename>RobotoCondensed-Light.ttf</filename>
+            <size>130</size>
+        </font>
+        <font>
+            <name>font_musicvis_big</name>
+            <filename>RobotoCondensed-Light.ttf</filename>
+            <size>80</size>
+        </font>
+
+        <!-- Music visualisation info -->
+        <font>
+            <name>font_lyrics_bold</name>
+            <filename>RobotoCondensed-Bold.ttf</filename>
+            <size>70</size>
+        </font>
+
+        <font>
+            <name>font_splash</name>
+            <filename>RobotoCondensed-Bold.ttf</filename>
+            <size>80</size>
+            <style>bold</style>
+        </font>
+        <!-- Big weather temp -->
+        <font>
+            <name>font_weather_currenttemp</name>
+            <filename>RobotoCondensed-Bold.ttf</filename>
+            <size>150</size>
+            <style>bold</style>
+        </font>
+        <font>
+            <name>font_weather_bold</name>
+            <filename>RobotoCondensed-Bold.ttf</filename>
+            <size>42</size>
+            <style>bold</style>
+        </font>
+
+        <!-- Plot info overlay -->
+        <font>
+            <name>font_overlay_title</name>
+            <filename>RobotoCondensed-Bold.ttf</filename>
+            <size>100</size>
+            <aspect>0.9</aspect>
+            <style>bold</style>
+        </font>
+
+
+        <!-- Showcase title font -->
+        <font>
+            <name>font_title_large</name>
+            <filename>RobotoCondensed-Bold.ttf</filename>
+            <size>60</size>
+            <aspect>0.9</aspect>
+            <style>bold</style>
+        </font>
+        <font>
+            <name>font_title</name>
+            <filename>RobotoCondensed-Bold.ttf</filename>
+            <size>52</size>
+            <aspect>0.9</aspect>
+            <style>bold</style>
+        </font>
+        <font>
+            <name>font_title_small</name>
+            <filename>RobotoCondensed-Bold.ttf</filename>
+            <size>44</size>
+            <aspect>0.9</aspect>
+            <style>bold</style>
+        </font>
+        <font>
+            <name>font_title_mini</name>
+            <filename>RobotoCondensed-Bold.ttf</filename>
+            <size>33</size>
+            <aspect>0.9</aspect>
+            <style>bold</style>
+        </font>
+        <font>
+            <name>font_topbar</name>
+            <filename>RobotoCondensed-Bold.ttf</filename>
+            <size>44</size>
+            <aspect>0.9</aspect>
+            <style>bold</style>
+        </font>
+        <font>
+            <name>font_topbar_small</name>
+            <filename>RobotoCondensed-Regular.ttf</filename>
+            <size>33</size>
+        </font>
+
+        <font>
+            <name>font_mainmenu</name>
+            <filename>RobotoCondensed-Bold.ttf</filename>
+            <size>37</size>
+            <!-- <aspect>0.9</aspect> -->
+            <style>bold</style>
+        </font>
+        <font>
+            <name>font_mainmenu_small</name>
+            <filename>RobotoCondensed-Regular.ttf</filename>
+            <size>33</size>
+        </font>
+
+        <font>
+            <name>font_submenu</name>
+            <filename>RobotoCondensed-Bold.ttf</filename>
+            <size>31</size>
+            <aspect>0.9</aspect>
+            <style>bold</style>
+        </font>
+        <font>
+            <name>font_submenu_small</name>
+            <filename>RobotoCondensed-Regular.ttf</filename>
+            <size>29</size>
+        </font>
+        <font>
+            <name>font_notification</name>
+            <filename>RobotoCondensed-Bold.ttf</filename>
+            <size>33</size>
+            <aspect>0.9</aspect>
+            <style>bold</style>
+        </font>
+
+        <!-- Small Byline -->
+        <font>
+            <name>font_byline</name>
+            <style>uppercase</style>
+            <filename>RobotoCondensed-Bold-Caps.ttf</filename>
+            <size>24</size>
+        </font>
+        <font>
+            <name>font_hintlabel</name>
+            <style>uppercase bold</style>
+            <filename>RobotoCondensed-Bold.ttf</filename>
+            <size>20</size>
+        </font>
+
+        <!-- Required for system -->
+        <font>
+            <name>font13</name>
+            <filename>RobotoCondensed-Regular.ttf</filename>
+            <size>33</size>
+        </font>
+        <font>
+            <name>Clock</name>
+            <filename>RobotoCondensed-Bold.ttf</filename>
+            <size>130</size>
+        </font>
+
+        <include>VideoLyrics_Fonts</include>
+
+    </fontset>
 
 </fonts>

--- a/1080i/Includes.xml
+++ b/1080i/Includes.xml
@@ -31,6 +31,7 @@
     <include file="Includes_Labels.xml" />
     <include file="Includes_Object.xml" />
     <include file="Includes_OSD.xml" />
+    <include file="Includes_PVRWidgets.xml" />
     <include file="Includes_Topbar.xml" />
     <include file="Includes_VideoLyrics.xml" />
     <include file="Includes_Weather.xml" />

--- a/1080i/Includes_Home.xml
+++ b/1080i/Includes_Home.xml
@@ -173,6 +173,9 @@
                                 <effect type="slide" end="0,-20" time="60" tween="sine" />
                                 <effect type="slide" end="0,20" time="180" tween="sine" delay="80" />
                             </animation>
+                            <animation condition="String.IsEqual(Container(3700).ListItemAbsolute(0).Property(list),TVPVRRecordingWidget) + [PVR.IsRecordingTV | PVR.HasNonRecordingTVTimer]">
+                                <effect type="slide" start="0,0" end="0,250" time="0" tween="sine" /> 
+                            </animation>
                             <include>skinshortcuts-template-widgets</include>
                             <control type="group">
                                 <visible>String.IsEqual(Container(3700).ListItemAbsolute(0).Property(list),Weather) + Weather.IsFetched</visible>
@@ -185,6 +188,14 @@
                                     <top>20</top>
                                     <bottom>20</bottom>
                                 </include>
+                            </control>
+                            <control type="group">
+                                <visible>String.IsEqual(Container(3700).ListItemAbsolute(0).Property(list),TVPVRRecordingWidget) + [PVR.IsRecordingTV | PVR.HasNonRecordingTVTimer]</visible>
+                                <include content="Animation_UpDown">
+                                    <param name="visible" value="String.IsEqual(Container(3700).ListItemAbsolute(0).Property(list),TVPVRRecordingWidget) + [PVR.IsRecordingTV | PVR.HasNonRecordingTVTimer]" />
+                                </include>
+                                <top>-400</top>
+                                <include>PVRTVRecordingWidget</include>
                             </control>
                             <control type="group">
                                 <visible>Integer.IsEqual(Container(3700).NumItems,0)</visible>

--- a/1080i/Includes_OSD.xml
+++ b/1080i/Includes_OSD.xml
@@ -86,6 +86,10 @@
 
                     <!-- Album Cover -->
                     <control type="group">
+                        <animation type="Conditional" reversible="false" condition="Skin.HasSetting(BottomMusicOSD)">
+                            <effect type="slide" start="0,0" end="-350,530" time="0" delay="0"/>
+                            <effect type="zoom" end="60,60" time="0" delay="0"/>
+                        </animation>
                         <include content="OSD_Music_Info_Image_Square">
                             <param name="artwork" value="$PARAM[artwork]" />
                         </include>

--- a/1080i/Includes_PVRWidgets.xml
+++ b/1080i/Includes_PVRWidgets.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<includes>
+
+    <!-- PVR Recording widget -->
+    <include name="PVRTVRecordingWidget">
+        <control type="grouplist" id="12855">
+            <include>Defs_InfoDialog_Visible</include>
+            <top>view_pad</top>
+            <left>view_pad</left>
+            <height>390</height>
+            <orientation>horizontal</orientation>
+            <align>left</align>
+            <control type="group">
+                <width>674</width>
+                <visible>PVR.IsRecordingTV</visible>
+                <include content="PVRWidget">
+                    <param name="icon" value="$INFO[PVR.TVNowRecordingChannelIcon]" />
+                    <param name="header" value="$LOCALIZE[19158]" />
+                    <param name="label1" value="$INFO[PVR.TVNowRecordingDateTime]" />
+                    <param name="label2" value="$INFO[PVR.TVNowRecordingTitle]" />
+                    <param name="label3" value="$INFO[PVR.TVNowRecordingChannel]" />
+                </include>
+            </control>
+            <control type="group">
+                <width>674</width>
+                <visible>PVR.HasNonRecordingTVTimer</visible>
+                <include content="PVRWidget">
+                    <param name="icon" value="$INFO[PVR.TVNextRecordingChannelIcon]" />
+                    <param name="header" value="$LOCALIZE[19157]" />
+                    <param name="label1" value="$INFO[PVR.TVNextRecordingDateTime]" />
+                    <param name="label2" value="$INFO[PVR.TVNextRecordingTitle]" />
+                    <param name="label3" value="$INFO[PVR.TVNextRecordingChannel]" />
+                </include>
+            </control>
+        </control>
+    </include>
+
+    <include name="PVRWidget">
+        <control type="image">
+            <description>background image</description>
+            <top>75</top>
+            <width>692</width>
+            <height>247</height>
+            <bordersize>15</bordersize>
+            <aspectratio scalediffuse="false">scale</aspectratio>
+            <texture border="30" colordiffuse="panel_fg_12">common/box.png</texture>
+        </control>
+        <control type="image">
+            <left>55</left>
+            <top>122</top>
+            <width>140</width>
+            <height>140</height>
+            <aspectratio>keep</aspectratio>
+            <texture background="true" fallback="DefaultVideo.png">$PARAM[icon]</texture>
+        </control>
+        <control type="label">
+            <left>225</left>
+            <top>127</top>
+            <height>25</height>
+            <width>420</width>
+            <label>$PARAM[header]</label>
+            <aligny>center</aligny>
+            <font>font_small_bold</font>
+            <textcolor>panel_fg_100</textcolor>
+        </control>
+        <control type="label">
+            <left>225</left>
+            <top>172</top>
+            <height>105</height>
+            <width>420</width>
+            <label>$PARAM[label1][CR]$PARAM[label2][CR]$PARAM[label3]</label>
+            <font>font_tiny</font>
+            <textcolor>panel_fg_100</textcolor>
+        </control>
+    </include>
+
+
+</includes>

--- a/1080i/Includes_Topbar.xml
+++ b/1080i/Includes_Topbar.xml
@@ -44,7 +44,7 @@
                 <visible>!Window.IsVisible(DialogVolumeBar.xml) | Player.Muted</visible>
                 <visible>!Player.HasMedia | Window.IsVisible(fullscreenvideo)</visible>
                 <control type="grouplist">
-                    <visible>!Control.HasFocus(60) + !Control.HasFocus(64)</visible>
+                    <visible>[!Control.HasFocus(60) + !Control.HasFocus(64)] | Skin.HasSetting(EnableShowItemCount)</visible>
                     <right>view_pad</right>
                     <align>right</align>
                     <orientation>horizontal</orientation>
@@ -89,7 +89,10 @@
                     </control>
                 </control>
                 <control type="grouplist">
-                    <visible>Control.HasFocus(60) | Control.HasFocus(64)</visible>
+                    <visible>Control.HasFocus(60) | Control.HasFocus(64) | Skin.HasSetting(EnableShowItemCount) + !String.IsEmpty(Container.NumItems)</visible>
+                    <animation type="Conditional" reversible="false" condition="Skin.HasSetting(EnableShowItemCount) + !Skin.HasSetting(DisableClock)">
+                        <effect type="slide" start="0,0" end="0,50" time="0" delay="0"/>
+                    </animation>
                     <right>view_pad</right>
                     <align>right</align>
                     <orientation>horizontal</orientation>

--- a/1080i/Includes_Viewtype.xml
+++ b/1080i/Includes_Viewtype.xml
@@ -679,10 +679,15 @@
                     <height>$PARAM[textbox-height]</height>
                     <visible>$PARAM[textbox-visible]</visible>
                     <bottom>0</bottom>
-                    <include content="$PARAM[label-include]" description="Unfocused" condition="$PARAM[textpanel]">
+                    <include content="$PARAM[label-include]" description="Unfocused" condition="!Skin.HasSetting(EnableHighContrastWidgetText) + $PARAM[textpanel]">
                         <param name="visible" value="!Control.HasFocus($PARAM[id]) | !$PARAM[selectbox]" />
                         <param name="textcolor_100" value="panel_fg_30" />
                         <param name="textcolor_70" value="panel_fg_30" />
+                    </include>
+                    <include content="$PARAM[label-include]" description="Unfocused" condition="Skin.HasSetting(EnableHighContrastWidgetText) + $PARAM[textpanel]">
+                        <param name="visible" value="!Control.HasFocus($PARAM[id]) | !$PARAM[selectbox]" />
+                        <param name="textcolor_100" value="panel_fg_70" />
+                        <param name="textcolor_70" value="panel_fg_70" />
                     </include>
                     <include content="$PARAM[label-include]" description="Focused" condition="Skin.HasSetting(EnableMonochromeHighlight) + $PARAM[textpanel]">
                         <param name="visible" value="Control.HasFocus($PARAM[id]) + $PARAM[selectbox]" />
@@ -701,10 +706,17 @@
                     <height>$PARAM[textbox-height]</height>
                     <visible>$PARAM[textbox-visible]</visible>
                     <bottom>-10</bottom>
-                    <include content="$PARAM[label-include]" description="Unfocused" condition="!$PARAM[textpanel]">
+                    <include content="$PARAM[label-include]" description="Unfocused" condition="!Skin.HasSetting(EnableHighContrastWidgetText) + !$PARAM[textpanel]">
                         <param name="visible" value="!Control.HasFocus($PARAM[id]) | !$PARAM[selectbox]" />
                         <param name="textcolor_100" value="main_fg_30" />
                         <param name="textcolor_70" value="main_fg_30" />
+                        <param name="align" value="left" />
+                        <param name="pad" value="15" />
+                    </include>
+                    <include content="$PARAM[label-include]" description="Unfocused" condition="Skin.HasSetting(EnableHighContrastWidgetText) + !$PARAM[textpanel]">
+                        <param name="visible" value="!Control.HasFocus($PARAM[id]) | !$PARAM[selectbox]" />
+                        <param name="textcolor_100" value="main_fg_70" />
+                        <param name="textcolor_70" value="main_fg_70" />
                         <param name="align" value="left" />
                         <param name="pad" value="15" />
                     </include>

--- a/1080i/SkinSettings.xml
+++ b/1080i/SkinSettings.xml
@@ -501,6 +501,14 @@
                         <selected>Skin.HasSetting(WallShowInfo)</selected>
                     </control>
 
+                    <control type="radiobutton" id="19440" description="Show page and item counts below weather/time">
+                        <visible>Integer.IsEqual(Window.Property(CurrentFocus),9004)</visible>
+                        <include>Defs_Settings_Button</include>
+                        <label>$LOCALIZE[31436]</label>
+                        <selected>Skin.HasSetting(EnableShowItemCount)</selected>
+                        <onclick>Skin.ToggleSetting(EnableShowItemCount)</onclick>
+                    </control>
+
 
                     <!-- ================= -->
                     <!-- Video / Music OSD -->

--- a/1080i/SkinSettings.xml
+++ b/1080i/SkinSettings.xml
@@ -650,6 +650,13 @@
                         <selected>Skin.HasSetting(AutoMusicVis)</selected>
                         <onclick>Skin.ToggleSetting(AutoMusicVis)</onclick>
                     </control>
+                    <control type="radiobutton" id="19517" description="AutoMusicVis">
+                        <visible>Integer.IsEqual(Window.Property(CurrentFocus),9005)</visible>
+                        <include>Defs_Settings_Button</include>
+                        <label>$LOCALIZE[31437]</label>
+                        <selected>Skin.HasSetting(BottomMusicOSD)</selected>
+                        <onclick>Skin.ToggleSetting(BottomMusicOSD)</onclick>
+                    </control>
 
                     <!-- ============= -->
                     <!-- Live TV / PVR -->

--- a/1080i/SkinSettings.xml
+++ b/1080i/SkinSettings.xml
@@ -390,6 +390,14 @@
                         <onclick>Skin.ToggleSetting(InvertHomeMenuColors)</onclick>
                     </control>
 
+                    <control type="radiobutton" id="19308" description="Use High Contrast Widget Text">
+                        <visible>Integer.IsEqual(Window.Property(CurrentFocus),9003)</visible>
+                        <include>Defs_Settings_Button</include>
+                        <label>$LOCALIZE[31435]</label>
+                        <selected>Skin.HasSetting(EnableHighContrastWidgetText)</selected>
+                        <onclick>Skin.ToggleSetting(EnableHighContrastWidgetText)</onclick>
+                    </control>
+
                     <control type="button" id="19306" description="Reset">
                         <visible>Integer.IsEqual(Window.Property(CurrentFocus),9003)</visible>
                         <include>Defs_Settings_Button</include>

--- a/language/resource.language.en_gb/strings.po
+++ b/language/resource.language.en_gb/strings.po
@@ -1438,3 +1438,10 @@ msgstr ""
 msgctxt "#31437"
 msgid "Move music osd to the bottom of the screen"
 msgstr ""
+
+#: /shortcuts/overrides.xml
+msgctxt "#31438"
+msgid "TV PVR Recording Widget (must be in first position)"
+msgstr ""
+
+

--- a/language/resource.language.en_gb/strings.po
+++ b/language/resource.language.en_gb/strings.po
@@ -1423,3 +1423,8 @@ msgstr ""
 msgctxt "#31434"
 msgid "Clearart with seekbar"
 msgstr "Clearart with seekbar"
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31435"
+msgid "Use higher contrast text for unselected widgets"
+msgstr ""

--- a/language/resource.language.en_gb/strings.po
+++ b/language/resource.language.en_gb/strings.po
@@ -1430,6 +1430,11 @@ msgid "Use higher contrast text for unselected widgets"
 msgstr ""
 
 #: /1080i/SkinSettings.xml
+msgctxt "#31436"
+msgid "Show page and item counts on list pages"
+msgstr ""
+
+#: /1080i/SkinSettings.xml
 msgctxt "#31437"
 msgid "Move music osd to the bottom of the screen"
 msgstr ""

--- a/language/resource.language.en_gb/strings.po
+++ b/language/resource.language.en_gb/strings.po
@@ -1428,3 +1428,8 @@ msgstr "Clearart with seekbar"
 msgctxt "#31435"
 msgid "Use higher contrast text for unselected widgets"
 msgstr ""
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31437"
+msgid "Move music osd to the bottom of the screen"
+msgstr ""

--- a/shortcuts/overrides.xml
+++ b/shortcuts/overrides.xml
@@ -7,6 +7,7 @@
     <widgetRename>True</widgetRename>
     <widget label="8">Weather</widget>
     <widget label="5">Settings</widget>
+    <widget label="$LOCALIZE[31438]">TVPVRRecordingWidget</widget>
 
     <!-- Warning to Remove Settings -->
     <warn heading="31176" message="31177">ActivateWindow(Settings)</warn>


### PR DESCRIPTION
Apologies for doing this as one PR (since they are separate things), but I can never figure out how to get Github to let me do multiple PRs on the same branch of something.  I did at least do each suggestion as a separate commit.

1- My poor old eyes have a hard time with the font size when I use this on our TV. So the first commit is just the same fonts by 10% larger (except the largest fonts, which stay the same).  I've checked just about every screen, and this doesn't seem to be causing any layout issues.

2- Another "hard to read" thing here.  This option (with a skin setting) updates the widget text (but not the widget titles) to a higher contrast from the background.

3- I like listening to music and have AS showing artist images (which makes sense since I maintain AS), but I also like to leave the info up to quickly see the artist name and album). This option (with skin setting) moves the album art to the lower left and reduces it's size.

4- On the list pages, I like being able to see the total count of items at a glace.  This option (with skin setting) makes the page/item count visible on pages that have that info right under the clock). I know I can get it my activating the scroll bar, but this allows it at a glance.

5- I really like the PVR status widget from Estuary, so the last commit (well actually the last two since I forgot one file the first time) brings that over to this skin.  It's a standard skin shortcuts widget, so folks can put it on any page. It just has to be in the first position to work right.

Thanks in advance for considering these.  I'll maintain them as a separate mod if I have to, but I'm dreaming of a day I can use a skin unmodified.  '-)