### PR TITLE
option for music info at bottom

### DIFF
--- a/1080i/Includes_OSD.xml
+++ b/1080i/Includes_OSD.xml
@@ -50,12 +50,16 @@
 
     <include name="OSD_Music_Info_Image_Square">
         <param name="side" default="OSD_LeftSide" />
+        <param name="centertop" default="50%" />
+        <param name="centerleft" default="50%" />
+        <param name="width" default="640" />
+        <param name="height" default="640" />
         <definition>
             <control type="group">
-                <centertop>50%</centertop>
-                <centerleft>50%</centerleft>
-                <width>640</width>
-                <height>640</height>
+                <centertop>$PARAM[centertop]</centertop>
+                <centerleft>$PARAM[centerleft]</centerleft>
+                <width>$PARAM[width]</width>
+                <height>$PARAM[height]</height>
                 <control type="image">
                     <aspectratio scalediffuse="false">scale</aspectratio>
                     <include condition="!Skin.HasSetting(DisableShadows)">Defs_Shadow_24</include>
@@ -64,6 +68,104 @@
             </control>
         </definition>
     </include>
+
+    <include name="OSD_Music_Info_Display">
+        <definition>
+            <!-- Album Cover -->
+            <control type="group">
+                <include content="OSD_Music_Info_Image_Square">
+                    <param name="artwork" value="$PARAM[artwork]" />
+                </include>
+                <control type="group">
+                    <width>800</width>
+                    <centerleft>50%</centerleft>
+                    <bottom>80</bottom>
+                    <include>OSD_Progress_Bar</include>
+                </control>
+            </control>
+            <control type="grouplist">
+                <visible>!Window.IsVisible(musicosd)</visible>
+                <width>640</width>
+                <top>890</top>
+                <orientation>vertical</orientation>
+                <centerleft>50%</centerleft>
+                <usecontrolcoords>true</usecontrolcoords>
+                <control type="label">
+                    <textcolor>panel_fg_100</textcolor>
+                    <font>font_title</font>
+                    <height>60</height>
+                    <align>center</align>
+                    <label>$INFO[MusicPlayer.Title]</label>
+                </control>
+                <control type="label">
+                    <textcolor>panel_fg_70</textcolor>
+                    <font>font_small_bold</font>
+                    <height>30</height>
+                    <align>center</align>
+                    <label>$INFO[MusicPlayer.Artist]</label>
+                </control>
+            </control>    
+        </definition>
+    </include>
+
+    <include name="OSD_Music_Info_Display_Bottom">
+        <definition>
+            <!-- Album Cover -->
+            <control type="group">
+                <include content="OSD_Music_Info_Image_Square">
+                    <param name="artwork" value="$PARAM[artwork]" />
+                    <param name="centertop" value="840" />
+                    <param name="centerleft" value="240" />
+                    <param name="width" value="320" />
+                    <param name="height" value="320" />
+                </include>
+                <control type="group">
+                    <bottom>-20</bottom>
+                    <width>1560</width>
+                    <left>360</left>
+                    <include>OSD_Progress_Bar</include>
+                </control>
+                <control type="group">
+                    <bottom>80</bottom>
+                    <left>440</left>
+                    <height>30</height>
+                    <width>1400</width>
+                    <control type="label">
+                        <textcolor>panel_fg_70</textcolor>
+                        <font>font_tiny_bold</font>
+                        <label>$INFO[Player.Time]</label>
+                    </control>
+                    <control type="label">
+                        <align>right</align>
+                        <textcolor>panel_fg_70</textcolor>
+                        <font>font_tiny_bold</font>
+                        <label>$INFO[Player.Duration]</label>
+                    </control>
+                </control>
+            </control>
+            <control type="grouplist">
+                <top>780</top>
+                <left>440</left>
+                <orientation>vertical</orientation>
+                <usecontrolcoords>true</usecontrolcoords>
+                <control type="label">
+                    <width>1400</width>
+                    <textcolor>panel_fg_100</textcolor>
+                    <font>font_title</font>
+                    <height>60</height>
+                    <label>$INFO[MusicPlayer.Title]</label>
+                </control>
+                <control type="label">
+                    <width>1400</width>
+                    <textcolor>panel_fg_70</textcolor>
+                    <font>font_small_bold</font>
+                    <height>30</height>
+                    <label>$INFO[MusicPlayer.Artist]</label>
+                </control>
+            </control>
+        </definition>
+    </include>
+
     <include name="OSD_Music_Info">
         <param name="player" default="MusicPlayer" />
         <param name="rating" default="MusicPlayer.UserRating" />
@@ -83,44 +185,35 @@
                     <animation effect="fade" start="0" end="100" time="300">VisibleChange</animation>
                     <include>Animation_FadeIn</include>
                     <include>Animation_FadeOut</include>
-
-                    <!-- Album Cover -->
-                    <control type="group">
-                        <include content="OSD_Music_Info_Image_Square">
-                            <param name="artwork" value="$PARAM[artwork]" />
-                        </include>
-                        <control type="group">
-                            <width>800</width>
-                            <centerleft>50%</centerleft>
-                            <bottom>80</bottom>
-                            <include>OSD_Progress_Bar</include>
-                        </control>
-                    </control>
                     <include>OSD_Clock</include>
-                    <control type="grouplist">
-                        <visible>!Window.IsVisible(musicosd)</visible>
-                        <width>640</width>
-                        <top>890</top>
-                        <orientation>vertical</orientation>
-                        <centerleft>50%</centerleft>
-                        <usecontrolcoords>true</usecontrolcoords>
-                        <control type="label">
-                            <textcolor>panel_fg_100</textcolor>
-                            <font>font_title</font>
-                            <height>60</height>
-                            <align>center</align>
-                            <label>$INFO[MusicPlayer.Title]</label>
-                        </control>
-                        <control type="label">
-                            <textcolor>panel_fg_70</textcolor>
-                            <font>font_small_bold</font>
-                            <height>30</height>
-                            <align>center</align>
-                            <label>$INFO[MusicPlayer.Artist]</label>
-                        </control>
-                    </control>
-
+                    <include condition="!Skin.HasSetting(BottomMusicOSD)" content="OSD_Music_Info_Display">
+                        <param name="artwork" value="$PARAM[artwork]" />
+                    </include>
+                    <include condition="Skin.HasSetting(BottomMusicOSD)" content="OSD_Music_Info_Display_Bottom">
+                        <param name="artwork" value="$PARAM[artwork]" />
+                    </include>
                 </control>
+            </control>
+        </definition>
+    </include>
+
+    <include name="OSD_MusicButtons">
+        <param name="left" default="0" />
+        <param name="width" default="1920" />
+        <param name="centerbottom" default="165" />
+        <definition>
+            <control type="group">
+            <left>$PARAM[left]</left>
+            <width>$PARAM[width]</width>
+            <control type="grouplist" id="9000">
+                <align>center</align>
+                <height>48</height>
+                <centerbottom>$PARAM[centerbottom]</centerbottom>
+                <itemgap>28</itemgap>
+                <orientation>horizontal</orientation>
+                <usecontrolcoords>true</usecontrolcoords>
+                <include>OSD_Controls</include>
+            </control>
             </control>
         </definition>
     </include>

--- a/1080i/MusicOSD.xml
+++ b/1080i/MusicOSD.xml
@@ -7,16 +7,14 @@
         <control type="group">
             <include>Animation_FadeIn</include>
             <include>Animation_FadeOut</include>
-            <control type="grouplist" id="9000">
-                <align>center</align>
-                <height>48</height>
-                <centerbottom>165</centerbottom>
-                <itemgap>28</itemgap>
-                <orientation>horizontal</orientation>
-                <usecontrolcoords>true</usecontrolcoords>
-                <include>OSD_Controls</include>
-            </control>
+            <include condition="!Skin.HasSetting(BottomMusicOSD)">OSD_MusicButtons</include>
+            <include condition="Skin.HasSetting(BottomMusicOSD)" content="OSD_MusicButtons">
+                <param name="left" value="480" />
+                <param name="width" value="1360" />
+                <param name="centerbottom" value="95" />
+            </include>
             <control type="group">
+                <visible>!Skin.HasSetting(BottomMusicOSD)</visible>
                 <height>30</height>
                 <width>640</width>
                 <centerbottom>108</centerbottom>

--- a/1080i/SkinSettings.xml
+++ b/1080i/SkinSettings.xml
@@ -642,6 +642,13 @@
                         <selected>Skin.HasSetting(AutoMusicVis)</selected>
                         <onclick>Skin.ToggleSetting(AutoMusicVis)</onclick>
                     </control>
+                    <control type="radiobutton" id="19517" description="AutoMusicVis">
+                        <visible>Integer.IsEqual(Window.Property(CurrentFocus),9005)</visible>
+                        <include>Defs_Settings_Button</include>
+                        <label>$LOCALIZE[31435]</label>
+                        <selected>Skin.HasSetting(BottomMusicOSD)</selected>
+                        <onclick>Skin.ToggleSetting(BottomMusicOSD)</onclick>
+                    </control>
 
                     <!-- ============= -->
                     <!-- Live TV / PVR -->

--- a/language/resource.language.en_gb/strings.po
+++ b/language/resource.language.en_gb/strings.po
@@ -1423,3 +1423,9 @@ msgstr ""
 msgctxt "#31434"
 msgid "Clearart with seekbar"
 msgstr "Clearart with seekbar"
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31435"
+msgid "Move music osd to the bottom of the screen"
+msgstr ""
+


### PR DESCRIPTION
OK, this should hopefully be a better starting point.  Screen shots below. I felt like the progress bar still didn't feel anchored without some text, so I pulled the total time and duration to use at the start and end points.  That left me a spot to nestle the OSD buttons too.

<img width="1390" alt="MusicInfowithScroll" src="https://user-images.githubusercontent.com/1402018/86543468-8f901380-beba-11ea-8218-5a439136ddfc.png">

<img width="1390" alt="MusicInfowithControls" src="https://user-images.githubusercontent.com/1402018/86543436-2b6d4f80-beba-11ea-83ae-099a7f02c3fa.png">

<img width="1390" alt="MusicInfo" src="https://user-images.githubusercontent.com/1402018/86543434-290af580-beba-11ea-9f64-2f5fc9481a0e.png">
