### PR TITLE
Higher contrast option

### DIFF
--- a/colors/Dark Higher Constrast.xml
+++ b/colors/Dark Higher Constrast.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<colors>
+    <!-- Main -->
+    <color name="main_fg_100">ffdedede</color>
+    <color name="main_fg_90">e7dedede</color>
+    <color name="main_fg_70">ccdedede</color>
+    <color name="main_fg_30">99dedede</color>
+    <color name="main_fg_12">1fdedede</color>
+
+    <color name="main_bg_100">ff181818</color>
+    <color name="main_bg_90">e7181818</color>
+    <color name="main_bg_70">cc181818</color>
+    <color name="main_bg_30">99181818</color>
+    <color name="main_bg_12">1f181818</color>
+
+    <!-- Dialogs -->
+    <color name="dialog_fg_100">ffededed</color>
+    <color name="dialog_fg_70">ccededed</color>
+    <color name="dialog_fg_30">99ededed</color>
+    <color name="dialog_fg_12">1fededed</color>
+
+    <color name="dialog_bg_100">ff181818</color>
+    <color name="dialog_bg_70">cc181818</color>
+    <color name="dialog_bg_30">99181818</color>
+    <color name="dialog_bg_12">1f181818</color>
+    
+    <!-- Panels -->
+    <color name="panel_bg">c5000000</color>
+    <color name="panel_fg_100">ffededed</color>
+    <color name="panel_fg_70">ccededed</color>
+    <color name="panel_fg_30">99ededed</color>
+    <color name="panel_fg_12">1fededed</color>
+
+    <!-- Background -->
+    <color name="HomePanel">e7181818</color>
+    <color name="Background">ff181818</color>
+    <color name="PosterBack">ff454545</color>
+    <color name="AltPosterBack">1fdedede</color>
+
+</colors>

--- a/colors/Default Higher Constrast.xml
+++ b/colors/Default Higher Constrast.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<colors>
+    <!-- Main -->
+    <color name="main_fg_100">ffdedede</color>
+    <color name="main_fg_90">e7dedede</color>
+    <color name="main_fg_70">ccdedede</color>
+    <color name="main_fg_30">99dedede</color>
+    <color name="main_fg_12">1fdedede</color>
+
+    <color name="main_bg_100">ff181818</color>
+    <color name="main_bg_90">e7181818</color>
+    <color name="main_bg_70">cc181818</color>
+    <color name="main_bg_30">99181818</color>
+    <color name="main_bg_12">1f181818</color>
+
+    <!-- Dialogs -->
+    <color name="dialog_bg_100">ffcccccc</color>
+    <color name="dialog_bg_70">cccccccc</color>
+    <color name="dialog_bg_30">99cccccc</color>
+    <color name="dialog_bg_12">1fcccccc</color>
+
+    <color name="dialog_fg_100">ff181818</color>
+    <color name="dialog_fg_70">cc181818</color>
+    <color name="dialog_fg_30">99181818</color>
+    <color name="dialog_fg_12">1f181818</color>
+
+    <!-- Panels -->
+    <color name="panel_bg">c5000000</color>
+    <color name="panel_fg_100">ffededed</color>
+    <color name="panel_fg_70">ccededed</color>
+    <color name="panel_fg_30">99ededed</color>
+    <color name="panel_fg_12">1fededed</color>
+
+</colors>


### PR DESCRIPTION
I know you said you didn't want to have a bunch of settings for every interface option, but I thought I'd submit this just in case (the work is done, so no big deal for me). This time instead of a single small change I create two new color options to make the changes global. Basically the various g_70 settings got a value that's actually 80% and the various g_30 settings got a value that's actually 50%. If you don't want to do that, that's absolutely fine. This change makes it way easier for me to just drop one file in after a skin update to get back what I need to be able to see things better.

P.S. I think I messed up my fork update and didn't rebase, so you're seeing an additional commit that is just me updating my fork with the updates from yours.  It's baby steps for me and git.  '-)