### PR TITLE
Slightly larger font

### DIFF
--- a/1080i/Custom_Overlay.xml
+++ b/1080i/Custom_Overlay.xml
@@ -975,7 +975,7 @@
                     <left>30</left>
                     <top>30</top>
                     <textcolor>FFFF00FF</textcolor>
-                    <font>font_small_mono</font>
+                    <font>font_small_mono_abs</font>
                     <shadowcolor>ff000000</shadowcolor>
                     <align>left</align>
                     <label>[COLOR=FFFFFF00]II  [/COLOR]$INFO[ListItem.Icon][CR][COLOR=FFFFFF00]AI  [/COLOR]$INFO[ListItem.ActualIcon][CR][COLOR=FFFFFF00]IT  [/COLOR]$INFO[ListItem.Art(thumb)][CR][COLOR=FFFFFF00]IP  [/COLOR]$INFO[ListItem.Art(poster)][CR][COLOR=FFFFFF00]IF  [/COLOR]$INFO[ListItem.Art(fanart)][CR][COLOR=FFFFFF00]TP  [/COLOR]$INFO[ListItem.Art(tvshow.poster)][CR][COLOR=FFFFFF00]TF  [/COLOR]$INFO[ListItem.Art(tvshow.fanart)][CR][COLOR=FFFFFF00]BI  [/COLOR]$INFO[Window(Home).Property(TMDbHelper.ListItem.BlurImage)][CR][COLOR=FFFFFF00]BS  [/COLOR]$INFO[Window(Home).Property(TMDbHelper.Blur.SourceImage)][CR][COLOR=FFFFFF00]BF  [/COLOR]$INFO[Window(Home).Property(TMDbHelper.Blur.Fallback)]</label>

--- a/1080i/DialogGameControllers.xml
+++ b/1080i/DialogGameControllers.xml
@@ -102,7 +102,7 @@
                 <right>200</right>
                 <align>center</align>
                 <description>Controller description</description>
-                <font>font_tiny</font>
+                <font>font_tiny_abs</font>
                 <textcolor>dialog_fg_70</textcolor>
             </control>
 

--- a/1080i/Font.xml
+++ b/1080i/Font.xml
@@ -20,7 +20,18 @@
             <size>30</size>
         </font>
         <font>
+            <name>font_small_abs</name>
+            <filename>RobotoCondensed-Regular.ttf</filename>
+            <size>30</size>
+        </font>
+        <font>
             <name>font_small_mono</name>
+            <filename>RobotoMono-Bold.ttf</filename>
+            <size>26</size>
+            <aspect>0.8</aspect>
+        </font>
+        <font>
+            <name>font_small_mono_abs</name>
             <filename>RobotoMono-Bold.ttf</filename>
             <size>26</size>
             <aspect>0.8</aspect>
@@ -36,7 +47,17 @@
             <size>26</size>
         </font>
         <font>
+            <name>font_tiny_abs</name>
+            <filename>RobotoCondensed-Regular.ttf</filename>
+            <size>26</size>
+        </font>
+        <font>
             <name>font_tiny_bold</name>
+            <filename>RobotoCondensed-Bold.ttf</filename>
+            <size>26</size>
+        </font>
+        <font>
+            <name>font_tiny_bold_abs</name>
             <filename>RobotoCondensed-Bold.ttf</filename>
             <size>26</size>
         </font>
@@ -48,6 +69,11 @@
         </font>
         <font>
             <name>font_statusbar</name>
+            <filename>RobotoCondensed-Regular.ttf</filename>
+            <size>22</size>
+        </font>
+        <font>
+            <name>font_statusbar_abs</name>
             <filename>RobotoCondensed-Regular.ttf</filename>
             <size>22</size>
         </font>
@@ -267,6 +293,308 @@
             <name>font13</name>
             <filename>RobotoCondensed-Regular.ttf</filename>
             <size>30</size>
+        </font>
+        <font>
+            <name>Clock</name>
+            <filename>RobotoCondensed-Bold.ttf</filename>
+            <size>130</size>
+        </font>
+
+        <include>VideoLyrics_Fonts</include>
+
+    </fontset>
+    <fontset id="Slightly Larger" unicode="true">
+
+        <!-- Standard Fonts -->
+        <font>
+            <name>font_medium</name>
+            <filename>RobotoCondensed-Regular.ttf</filename>
+            <size>42</size>
+        </font>
+        <font>
+            <name>font_medium_bold</name>
+            <filename>RobotoCondensed-Bold.ttf</filename>
+            <size>42</size>
+        </font>
+        <font>
+            <name>font_small</name>
+            <filename>RobotoCondensed-Regular.ttf</filename>
+            <size>33</size>
+        </font>
+        <font>
+            <name>font_small_abs</name>
+            <filename>RobotoCondensed-Regular.ttf</filename>
+            <size>30</size>
+        </font>
+        <font>
+            <name>font_small_mono</name>
+            <filename>RobotoMono-Bold.ttf</filename>
+            <size>30</size>
+            <aspect>0.8</aspect>
+        </font>
+        <font>
+            <name>font_small_mono_abs</name>
+            <filename>RobotoMono-Bold.ttf</filename>
+            <size>26</size>
+            <aspect>0.8</aspect>
+        </font>
+        <font>
+            <name>font_small_bold</name>
+            <filename>RobotoCondensed-Bold.ttf</filename>
+            <size>33</size>
+        </font>
+        <font>
+            <name>font_tiny</name>
+            <filename>RobotoCondensed-Regular.ttf</filename>
+            <size>29</size>
+        </font>
+        <font>
+            <name>font_tiny_abs</name>
+            <filename>RobotoCondensed-Regular.ttf</filename>
+            <size>26</size>
+        </font>
+        <font>
+            <name>font_tiny_bold</name>
+            <filename>RobotoCondensed-Bold.ttf</filename>
+            <size>29</size>
+        </font>
+        <font>
+            <name>font_tiny_bold_abs</name>
+            <filename>RobotoCondensed-Bold.ttf</filename>
+            <size>26</size>
+        </font>
+        <font>
+            <name>font_button</name>
+            <style>uppercase</style>
+            <filename>RobotoCondensed-Regular-Caps.ttf</filename>
+            <size>26</size>
+        </font>
+        <font>
+            <name>font_statusbar</name>
+            <filename>RobotoCondensed-Regular.ttf</filename>
+            <size>24</size>
+        </font>
+        <font>
+            <name>font_statusbar_abs</name>
+            <filename>RobotoCondensed-Regular.ttf</filename>
+            <size>22</size>
+        </font>
+        <font>
+            <name>font_fps</name>
+            <filename>RobotoCondensed-Regular.ttf</filename>
+            <size>18</size>
+        </font>
+        <font>
+            <name>font_osd_lang</name>
+            <filename>RobotoCondensed-Regular.ttf</filename>
+            <size>12</size>
+        </font>
+        <font>
+            <name>font_statusbar_bold</name>
+            <filename>RobotoCondensed-Bold.ttf</filename>
+            <size>24</size>
+        </font>
+        <font>
+            <name>font_info_buttons</name>
+            <filename>RobotoCondensed-Bold-Caps.ttf</filename>
+            <size>22</size>
+            <style>uppercase</style>
+        </font>
+        <font>
+            <name>font_unwatched</name>
+            <filename>RobotoCondensed-Bold.ttf</filename>
+            <size>18</size>
+        </font>
+        <font>
+            <name>font_mini</name>
+            <style>uppercase</style>
+            <filename>RobotoCondensed-Regular-Caps.ttf</filename>
+            <size>22</size>
+        </font>
+
+        <!-- Plot Font -->
+        <font>
+            <name>font_plotbox</name>
+            <filename>Roboto-Regular-Linespacing.ttf</filename>
+            <linespacing>1</linespacing>
+            <size>29</size>
+            <aspect>0.9</aspect>
+        </font>
+        <font>
+            <name>font_plotbox_small</name>
+            <filename>Roboto-Regular-Linespacing.ttf</filename>
+            <linespacing>1</linespacing>
+            <size>25</size>
+            <aspect>0.9</aspect>
+        </font>
+        <font>
+            <name>font_weather_small</name>
+            <filename>Roboto-Regular-Linespacing.ttf</filename>
+            <size>29</size>
+            <aspect>0.9</aspect>
+        </font>
+        <font>
+            <name>font_overlay_plotbox</name>
+            <filename>Roboto-Regular-Linespacing.ttf</filename>
+            <linespacing>1.45</linespacing>
+            <aspect>0.9</aspect>
+            <size>48</size>
+        </font>
+        <font>
+            <name>font_info_display</name>
+            <style>bold</style>
+            <filename>RobotoCondensed-Bold.ttf</filename>
+            <size>64</size>
+        </font>
+
+        <!-- Music visualisation scrolling text -->
+        <font>
+            <name>font_musicvis_biggest</name>
+            <filename>RobotoCondensed-Light.ttf</filename>
+            <size>230</size>
+        </font>
+        <font>
+            <name>font_musicvis_bigger</name>
+            <filename>RobotoCondensed-Light.ttf</filename>
+            <size>130</size>
+        </font>
+        <font>
+            <name>font_musicvis_big</name>
+            <filename>RobotoCondensed-Light.ttf</filename>
+            <size>80</size>
+        </font>
+
+        <!-- Music visualisation info -->
+        <font>
+            <name>font_lyrics_bold</name>
+            <filename>RobotoCondensed-Bold.ttf</filename>
+            <size>70</size>
+        </font>
+
+        <font>
+            <name>font_splash</name>
+            <filename>RobotoCondensed-Bold.ttf</filename>
+            <size>80</size>
+            <style>bold</style>
+        </font>
+        <!-- Big weather temp -->
+        <font>
+            <name>font_weather_currenttemp</name>
+            <filename>RobotoCondensed-Bold.ttf</filename>
+            <size>150</size>
+            <style>bold</style>
+        </font>
+        <font>
+            <name>font_weather_bold</name>
+            <filename>RobotoCondensed-Bold.ttf</filename>
+            <size>42</size>
+            <style>bold</style>
+        </font>
+
+        <!-- Plot info overlay -->
+        <font>
+            <name>font_overlay_title</name>
+            <filename>RobotoCondensed-Bold.ttf</filename>
+            <size>100</size>
+            <aspect>0.9</aspect>
+            <style>bold</style>
+        </font>
+
+
+        <!-- Showcase title font -->
+        <font>
+            <name>font_title_large</name>
+            <filename>RobotoCondensed-Bold.ttf</filename>
+            <size>60</size>
+            <aspect>0.9</aspect>
+            <style>bold</style>
+        </font>
+        <font>
+            <name>font_title</name>
+            <filename>RobotoCondensed-Bold.ttf</filename>
+            <size>52</size>
+            <aspect>0.9</aspect>
+            <style>bold</style>
+        </font>
+        <font>
+            <name>font_title_small</name>
+            <filename>RobotoCondensed-Bold.ttf</filename>
+            <size>44</size>
+            <aspect>0.9</aspect>
+            <style>bold</style>
+        </font>
+        <font>
+            <name>font_title_mini</name>
+            <filename>RobotoCondensed-Bold.ttf</filename>
+            <size>33</size>
+            <aspect>0.9</aspect>
+            <style>bold</style>
+        </font>
+        <font>
+            <name>font_topbar</name>
+            <filename>RobotoCondensed-Bold.ttf</filename>
+            <size>44</size>
+            <aspect>0.9</aspect>
+            <style>bold</style>
+        </font>
+        <font>
+            <name>font_topbar_small</name>
+            <filename>RobotoCondensed-Regular.ttf</filename>
+            <size>33</size>
+        </font>
+
+        <font>
+            <name>font_mainmenu</name>
+            <filename>RobotoCondensed-Bold.ttf</filename>
+            <size>37</size>
+            <!-- <aspect>0.9</aspect> -->
+            <style>bold</style>
+        </font>
+        <font>
+            <name>font_mainmenu_small</name>
+            <filename>RobotoCondensed-Regular.ttf</filename>
+            <size>33</size>
+        </font>
+
+        <font>
+            <name>font_submenu</name>
+            <filename>RobotoCondensed-Bold.ttf</filename>
+            <size>31</size>
+            <aspect>0.9</aspect>
+            <style>bold</style>
+        </font>
+        <font>
+            <name>font_submenu_small</name>
+            <filename>RobotoCondensed-Regular.ttf</filename>
+            <size>29</size>
+        </font>
+        <font>
+            <name>font_notification</name>
+            <filename>RobotoCondensed-Bold.ttf</filename>
+            <size>33</size>
+            <aspect>0.9</aspect>
+            <style>bold</style>
+        </font>
+
+        <!-- Small Byline -->
+        <font>
+            <name>font_byline</name>
+            <style>uppercase</style>
+            <filename>RobotoCondensed-Bold-Caps.ttf</filename>
+            <size>24</size>
+        </font>
+        <font>
+            <name>font_hintlabel</name>
+            <style>uppercase bold</style>
+            <filename>RobotoCondensed-Bold.ttf</filename>
+            <size>20</size>
+        </font>
+
+        <!-- Required for system -->
+        <font>
+            <name>font13</name>
+            <filename>RobotoCondensed-Regular.ttf</filename>
+            <size>33</size>
         </font>
         <font>
             <name>Clock</name>

--- a/1080i/GameOSD.xml
+++ b/1080i/GameOSD.xml
@@ -35,7 +35,7 @@
                         <left>30</left>
                         <right>30</right>
                         <height>130</height>
-                        <font>font_tiny</font>
+                        <font>font_tiny_abs</font>
                         <textcolor>dialog_fg_70</textcolor>
                     </control>
                     <control type="gamecontroller" id="1102">
@@ -50,7 +50,7 @@
                         <right>30</right>
                         <height>40</height>
                         <aligny>top</aligny>
-                        <font>font_tiny</font>
+                        <font>font_tiny_abs</font>
                         <textcolor>dialog_fg_70</textcolor>
                         <label>$LOCALIZE[35236]</label>
                     </control>

--- a/1080i/Includes_Dialog.xml
+++ b/1080i/Includes_Dialog.xml
@@ -1420,7 +1420,7 @@
                     <height>70</height>
                     <align>center</align>
                     <aligny>center</aligny>
-                    <font>font_tiny</font>
+                    <font>font_tiny_abs</font>
                     <textcolor>panel_fg_100</textcolor>
                 </control>
                 <control type="fixedlist" id="11">

--- a/1080i/Includes_OSD.xml
+++ b/1080i/Includes_OSD.xml
@@ -377,7 +377,7 @@
     </include>
 
      <include name="OSD_Menubar_Items">
-        <font>font_small</font>
+        <font>font_small_abs</font>
         <textcolor>panel_fg_100</textcolor>
         <aligny>center</aligny>
         <width>auto</width>

--- a/1080i/Includes_Object.xml
+++ b/1080i/Includes_Object.xml
@@ -230,7 +230,7 @@
                         <right>30</right>
                         <height>60</height>
                         <textcolor>dialog_fg_70</textcolor>
-                        <font>font_statusbar</font>
+                        <font>font_statusbar_abs</font>
                         <aligny>center</aligny>
                         <label>$PARAM[label]</label>
                     </control>
@@ -805,7 +805,7 @@
                     <height>40</height>
                     <aligny>top</aligny>
                     <textcolor>$VAR[ColorHighlight]</textcolor>
-                    <font>font_small</font>
+                    <font>font_small_abs</font>
                 </control>
                 <nested />
             </control>

--- a/1080i/Includes_Viewtype.xml
+++ b/1080i/Includes_Viewtype.xml
@@ -927,7 +927,7 @@
             <control type="textbox">
                 <left>35</left>
                 <right>35</right>
-                <font>font_tiny_bold</font>
+                <font>font_tiny_bold_abs</font>
                 <selectedcolor>$PARAM[textcolor_100]</selectedcolor>
                 <textcolor>$PARAM[textcolor_100]</textcolor>
                 <top>-3</top>


### PR DESCRIPTION
OK, new try at this. I went through and find all the places with either multiline or textbox so I'd know the places where a larger font would cause problems. I didn't change any of the lyric fonts (that handled all the multiline issues), and I didn't change plotfont (which handled a bunch of stuff). Where I did increase a font size that was in a textbox, I created a new font style ending in _abs and used that font style with a consistent size between the two font sets. I found two "regular" text lines that were too crowded larger (the info labels under titles and the info under the seekbar) and also made those absolute. Sharing mostly becasue the work is done now. If this still doesn't work for you, that's OK. It's an easy update if I have to maintain it on my own.

Same issue here as with the higher constrast options.  There's an extra commit because I didn't rebase correctly when merging changes from your main branch into my fork.