### PR TITLE
Updated Kodi action calls

### DIFF
--- a/1080i/Includes_Items.xml
+++ b/1080i/Includes_Items.xml
@@ -1537,23 +1537,23 @@
             <item>
                 <label>$LOCALIZE[31195]</label>
                 <visible>[String.IsEqual(ListItem.DBType,tvshow) | String.IsEqual(ListItem.DBType,movie) | String.IsEqual(ListItem.DBType,musicvideo) | String.IsEqual(ListItem.DBType,episode) | String.IsEqual(ListItem.DBType,artist) | String.IsEqual(ListItem.DBType,album) | String.IsEqual(ListItem.DBType,song)] + system.hasaddon(script.artwork.beef)</visible>
-                <onclick condition="String.IsEqual(ListItem.DBType,episode)">XBMC.RunScript(script.artwork.beef, mode=gui, mediatype=episode, dbid=$INFO[ListItem.DBID])</onclick>
-                <onclick condition="String.IsEqual(ListItem.DBType,tvshow)">XBMC.RunScript(script.artwork.beef, mode=gui, mediatype=tvshow, dbid=$INFO[ListItem.DBID])</onclick>
-                <onclick condition="String.IsEqual(ListItem.DBType,movie)">XBMC.RunScript(script.artwork.beef, mode=gui, mediatype=movie, dbid=$INFO[ListItem.DBID])</onclick>
-                <onclick condition="String.IsEqual(ListItem.DBType,artist)">XBMC.RunScript(script.artwork.beef, mode=gui, mediatype=artist, dbid=$INFO[ListItem.DBID])</onclick>
-                <onclick condition="String.IsEqual(ListItem.DBType,album)">XBMC.RunScript(script.artwork.beef, mode=gui, mediatype=album, dbid=$INFO[ListItem.DBID])</onclick>
-                <onclick condition="String.IsEqual(ListItem.DBType,song)">XBMC.RunScript(script.artwork.beef, mode=gui, mediatype=song, dbid=$INFO[ListItem.DBID])</onclick>
+                <onclick condition="String.IsEqual(ListItem.DBType,episode)">RunScript(script.artwork.beef, mode=gui, mediatype=episode, dbid=$INFO[ListItem.DBID])</onclick>
+                <onclick condition="String.IsEqual(ListItem.DBType,tvshow)">RunScript(script.artwork.beef, mode=gui, mediatype=tvshow, dbid=$INFO[ListItem.DBID])</onclick>
+                <onclick condition="String.IsEqual(ListItem.DBType,movie)">RunScript(script.artwork.beef, mode=gui, mediatype=movie, dbid=$INFO[ListItem.DBID])</onclick>
+                <onclick condition="String.IsEqual(ListItem.DBType,artist)">RunScript(script.artwork.beef, mode=gui, mediatype=artist, dbid=$INFO[ListItem.DBID])</onclick>
+                <onclick condition="String.IsEqual(ListItem.DBType,album)">RunScript(script.artwork.beef, mode=gui, mediatype=album, dbid=$INFO[ListItem.DBID])</onclick>
+                <onclick condition="String.IsEqual(ListItem.DBType,song)">RunScript(script.artwork.beef, mode=gui, mediatype=song, dbid=$INFO[ListItem.DBID])</onclick>
             </item>
             <item>
                 <label>$LOCALIZE[31197]</label>
                 <visible>[String.IsEqual(ListItem.DBType,tvshow) | String.IsEqual(ListItem.DBType,movie) | String.IsEqual(ListItem.DBType,musicvideo) | String.IsEqual(ListItem.DBType,episode) | String.IsEqual(ListItem.DBType,artist) | String.IsEqual(ListItem.DBType,album) | String.IsEqual(ListItem.DBType,song)] + system.hasaddon(script.artwork.beef)</visible>
                 <onclick>Back</onclick>
-                <onclick condition="String.IsEqual(ListItem.DBType,episode)">XBMC.RunScript(script.artwork.beef, mode=auto, mediatype=tvshow, dbid=$INFO[ListItem.DBID])</onclick>
-                <onclick condition="String.IsEqual(ListItem.DBType,tvshow)">XBMC.RunScript(script.artwork.beef, mode=auto, mediatype=tvshow, dbid=$INFO[ListItem.DBID])</onclick>
-                <onclick condition="String.IsEqual(ListItem.DBType,movie)">XBMC.RunScript(script.artwork.beef, mode=auto, mediatype=movie, dbid=$INFO[ListItem.DBID])</onclick>
-                <onclick condition="String.IsEqual(ListItem.DBType,artist)">XBMC.RunScript(script.artwork.beef, mode=auto, mediatype=artist, dbid=$INFO[ListItem.DBID])</onclick>
-                <onclick condition="String.IsEqual(ListItem.DBType,album)">XBMC.RunScript(script.artwork.beef, mode=auto, mediatype=album, dbid=$INFO[ListItem.DBID])</onclick>
-                <onclick condition="String.IsEqual(ListItem.DBType,song)">XBMC.RunScript(script.artwork.beef, mode=auto, mediatype=song, dbid=$INFO[ListItem.DBID])</onclick>
+                <onclick condition="String.IsEqual(ListItem.DBType,episode)">RunScript(script.artwork.beef, mode=auto, mediatype=tvshow, dbid=$INFO[ListItem.DBID])</onclick>
+                <onclick condition="String.IsEqual(ListItem.DBType,tvshow)">RunScript(script.artwork.beef, mode=auto, mediatype=tvshow, dbid=$INFO[ListItem.DBID])</onclick>
+                <onclick condition="String.IsEqual(ListItem.DBType,movie)">RunScript(script.artwork.beef, mode=auto, mediatype=movie, dbid=$INFO[ListItem.DBID])</onclick>
+                <onclick condition="String.IsEqual(ListItem.DBType,artist)">RunScript(script.artwork.beef, mode=auto, mediatype=artist, dbid=$INFO[ListItem.DBID])</onclick>
+                <onclick condition="String.IsEqual(ListItem.DBType,album)">RunScript(script.artwork.beef, mode=auto, mediatype=album, dbid=$INFO[ListItem.DBID])</onclick>
+                <onclick condition="String.IsEqual(ListItem.DBType,song)">RunScript(script.artwork.beef, mode=auto, mediatype=song, dbid=$INFO[ListItem.DBID])</onclick>
             </item>
             <item>
                 <label>$LOCALIZE[31204]</label>

--- a/1080i/Includes_OSD.xml
+++ b/1080i/Includes_OSD.xml
@@ -757,7 +757,7 @@
             <texturefocus colordiffuse="$VAR[ColorHighlight]">osd/repeat-off.png</texturefocus>
             <texturenofocus colordiffuse="panel_fg_70">osd/repeat-off.png</texturenofocus>
             <include>OSD_Button_OnFocus</include>
-            <onclick>XBMC.PlayerControl(Repeat)</onclick>
+            <onclick>PlayerControl(Repeat)</onclick>
             <visible>Window.IsVisible(musicosd)</visible>
             <visible>!Playlist.IsRepeatOne + !Playlist.IsRepeat</visible>
         </control>
@@ -774,7 +774,7 @@
             <texturefocus colordiffuse="$VAR[ColorHighlight]">osd/repeat-one.png</texturefocus>
             <texturenofocus colordiffuse="panel_fg_70">osd/repeat-one.png</texturenofocus>
             <include>OSD_Button_OnFocus</include>
-            <onclick>XBMC.PlayerControl(Repeat)</onclick>
+            <onclick>PlayerControl(Repeat)</onclick>
             <visible>Window.IsVisible(musicosd)</visible>
             <visible>Playlist.IsRepeatOne</visible>
         </control>
@@ -791,7 +791,7 @@
             <texturefocus colordiffuse="$VAR[ColorHighlight]">osd/repeat-all.png</texturefocus>
             <texturenofocus colordiffuse="panel_fg_70">osd/repeat-all.png</texturenofocus>
             <include>OSD_Button_OnFocus</include>
-            <onclick>XBMC.PlayerControl(Repeat)</onclick>
+            <onclick>PlayerControl(Repeat)</onclick>
             <visible>Window.IsVisible(musicosd)</visible>
             <visible>Playlist.IsRepeat</visible>
         </control>
@@ -808,7 +808,7 @@
             <alttexturefocus colordiffuse="$VAR[ColorHighlight]">osd/shuffle-on.png</alttexturefocus>
             <alttexturenofocus colordiffuse="panel_fg_70">osd/shuffle-on.png</alttexturenofocus>
             <include>OSD_Button_OnFocus</include>
-            <onclick>XBMC.PlayerControl(Random)</onclick>
+            <onclick>PlayerControl(Random)</onclick>
             <visible>Window.IsVisible(musicosd)</visible>
         </control>
         <!-- <control type="button" id="24">

--- a/1080i/Includes_Object.xml
+++ b/1080i/Includes_Object.xml
@@ -432,9 +432,9 @@
                 <onback>SetFocus(5000)</onback>
                 <onback>8000</onback>
                 <onclick condition="!System.HasAddon(script.artwork.beef) | ![String.IsEqual(ListItem.DBType,episode) | String.IsEqual(ListItem.DBType,tvshow) | String.IsEqual(ListItem.DBType,movie)]">SendClick(10)</onclick>
-                <onclick condition="String.IsEqual(ListItem.DBType,episode) + System.HasAddon(script.artwork.beef)">XBMC.RunScript(script.artwork.beef, mode=gui, mediatype=episode, dbid=$INFO[ListItem.DBID])</onclick>
-                <onclick condition="String.IsEqual(ListItem.DBType,tvshow) + System.HasAddon(script.artwork.beef)">XBMC.RunScript(script.artwork.beef, mode=gui, mediatype=tvshow, dbid=$INFO[ListItem.DBID])</onclick>
-                <onclick condition="String.IsEqual(ListItem.DBType,movie) + System.HasAddon(script.artwork.beef)">XBMC.RunScript(script.artwork.beef, mode=gui, mediatype=movie, dbid=$INFO[ListItem.DBID])</onclick>
+                <onclick condition="String.IsEqual(ListItem.DBType,episode) + System.HasAddon(script.artwork.beef)">RunScript(script.artwork.beef, mode=gui, mediatype=episode, dbid=$INFO[ListItem.DBID])</onclick>
+                <onclick condition="String.IsEqual(ListItem.DBType,tvshow) + System.HasAddon(script.artwork.beef)">RunScript(script.artwork.beef, mode=gui, mediatype=tvshow, dbid=$INFO[ListItem.DBID])</onclick>
+                <onclick condition="String.IsEqual(ListItem.DBType,movie) + System.HasAddon(script.artwork.beef)">RunScript(script.artwork.beef, mode=gui, mediatype=movie, dbid=$INFO[ListItem.DBID])</onclick>
                 <nested />
             </control>
             <control type="group">

--- a/shortcuts/mainmenu.DATA.xml
+++ b/shortcuts/mainmenu.DATA.xml
@@ -63,6 +63,6 @@
         <label2>32034</label2>
         <icon>DefaultDVDFull.png</icon>
         <thumb />
-        <action>XBMC.PlayDVD()</action>
+        <action>PlayDVD()</action>
     </shortcut>
 </shortcuts>

--- a/shortcuts/powermenu.DATA.xml
+++ b/shortcuts/powermenu.DATA.xml
@@ -9,35 +9,35 @@
     <shortcut>
         <label2>Power Menu Shortcut</label2>
         <label>13012</label>
-        <action>XBMC.Quit()</action>
+        <action>Quit()</action>
         <visible>System.ShowExitButton</visible>
         <icon>special://skin/extras/icons/power.png</icon>
     </shortcut>
     <shortcut>
         <label2>Power Menu Shortcut</label2>
         <label>13016</label>
-        <action>XBMC.Powerdown()</action>
+        <action>Powerdown()</action>
         <visible>System.CanPowerDown</visible>
         <icon>special://skin/extras/icons/power.png</icon>
     </shortcut>
     <shortcut>
         <label2>Power Menu Shortcut</label2>
         <label>13011</label>
-        <action>XBMC.Suspend()</action>
+        <action>Suspend()</action>
         <visible>System.CanSuspend</visible>
         <icon>special://skin/extras/icons/power.png</icon>
     </shortcut>
     <shortcut>
         <label2>Power Menu Shortcut</label2>
         <label>13010</label>
-        <action>XBMC.Hibernate()</action>
+        <action>Hibernate()</action>
         <visible>System.CanHibernate</visible>
         <icon>special://skin/extras/icons/power.png</icon>
     </shortcut>
     <shortcut>
         <label2>Power Menu Shortcut</label2>
         <label>13013</label>
-        <action>XBMC.Reset()</action>
+        <action>Reset()</action>
         <visible>System.CanReboot</visible>
         <icon>special://skin/extras/icons/power.png</icon>
     </shortcut>
@@ -62,21 +62,21 @@
     <shortcut>
         <label2>Power Menu Shortcut</label2>
         <label>13017</label>
-        <action>XBMC.InhibitIdleShutdown(true)</action>
+        <action>InhibitIdleShutdown(true)</action>
         <visible>System.HasShutdown +!System.IsInhibit</visible>
         <icon>special://skin/extras/icons/power.png</icon>
     </shortcut>
     <shortcut>
         <label2>Power Menu Shortcut</label2>
         <label>13018</label>
-        <action>XBMC.InhibitIdleShutdown(false)</action>
+        <action>InhibitIdleShutdown(false)</action>
         <visible>System.HasShutdown + System.IsInhibit</visible>
         <icon>special://skin/extras/icons/power.png</icon>
     </shortcut>
     <shortcut>
         <label2>Power Menu Shortcut</label2>
         <label>20150</label>
-        <action>XBMC.AlarmClock(shutdowntimer,XBMC.Shutdown())</action>
+        <action>AlarmClock(shutdowntimer,Shutdown())</action>
         <visible>!System.HasAlarm(shutdowntimer)</visible>
         <visible>System.CanPowerDown | System.CanSuspend | System.CanHibernate</visible>
         <icon>special://skin/extras/icons/power.png</icon>
@@ -84,7 +84,7 @@
     <shortcut>
         <label2>Power Menu Shortcut</label2>
         <label>20151</label>
-        <action>XBMC.CancelAlarm(shutdowntimer)</action>
+        <action>CancelAlarm(shutdowntimer)</action>
         <visible>System.HasAlarm(shutdowntimer)</visible>
         <icon>special://skin/extras/icons/power.png</icon>
     </shortcut>


### PR DESCRIPTION
For Kodi 19, the XBMC. format for action item calls has been removed (it was depreciated some time ago but continued working through Kodi 18). This change updates all the calls. The updated calls will work in Kodi 18 and are required for Kodi 19. One note: to get the power menu to update properly, I had to delete the powermenu entry from the script.skinshortcuts addondata directory so that the skin would regenerate a new one. I'm not sure if there's a better way to handle that.