### PR TITLE
Added en_us language strings

### DIFF
--- a/language/resource.language.en_gb/strings.po
+++ b/language/resource.language.en_gb/strings.po
@@ -766,7 +766,7 @@ msgstr ""
 
 #: /1080i/Custom_1117_ColorPicker.xml
 msgctxt "#31154"
-msgid "Color"
+msgid "Colour"
 msgstr ""
 
 #: /1080i/SkinSettings.xml

--- a/language/resource.language.en_us/strings.po
+++ b/language/resource.language.en_us/strings.po
@@ -1,0 +1,108 @@
+# Kodi Media Center language file
+# Addon Name: Horizon
+# Addon id: skin.horizon
+# Addon Provider: jurialmunkey
+msgid ""
+msgstr ""
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: en\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31021"
+msgid "Colours"
+msgstr "Colors"
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31027"
+msgid "Customise power menu"
+msgstr "Customize power menu"
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31042"
+msgid "Invert colours"
+msgstr "Invert colors"
+
+#: /1080i/script-skinshortcuts.xml
+msgctxt "#31049"
+msgid "Customise"
+msgstr "Customize"
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31060"
+msgid "Customise wall view"
+msgstr "Customize wall view"
+
+#: /1080i/Custom_1122_EnableWallViews.xml
+msgctxt "#31085"
+msgid "Customise wall views"
+msgstr "Customize wall views"
+
+#: /1080i/Custom_1122_EnableWallViews.xml
+msgctxt "#31086"
+msgid "Customise wall view for content types"
+msgstr "Customize wall view for content types"
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31087"
+msgid "Colour overlay"
+msgstr "Color overlay"
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31093"
+msgid "Customise viewtypes"
+msgstr "Customize viewtypes"
+
+msgctxt "#31109"
+msgid "Customise home menu"
+msgstr "Customize home menu"
+
+msgctxt "#31119"
+msgid "Visualisation behind slideshow"
+msgstr "Visualization behind slideshow"
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31129"
+msgid "Gradient colour"
+msgstr "Gradient color"
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31130"
+msgid "Overlay colour"
+msgstr "Overlay color"
+
+#: /1080i/MusicOSD.xml
+msgctxt "#31131"
+msgid "Colour overlay"
+msgstr "Color overlay"
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31136"
+msgid "Music Visualisation"
+msgstr "Music Visualization"
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31137"
+msgid "Fullscreen Video"
+msgstr ""
+
+#: /1080i/Custom_1117_ColorPicker.xml
+msgctxt "#31154"
+msgid "Colour"
+msgstr "Color"
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31166"
+msgid "Customise search lists"
+msgstr "Customize search lists"
+
+msgctxt "#31286"
+msgid "Highlight colour"
+msgstr "Highlight color"
+
+#: /1080i/Startup.xml
+msgctxt "#31349"
+msgid "Initialising Skin"
+msgstr "Initializing Skin"


### PR DESCRIPTION
This is a partial language file just to adjust for the rebellion spelling for some of the Queen's English.  '-)  I also fixed one instance in the en_gb file where colour was spelled color (just so it's always consistent in the en_gb file).