### PR TITLE
Enable views for the Advanced Emulator Launcher plugin

### DIFF
--- a/1080i/Includes_Items.xml
+++ b/1080i/Includes_Items.xml
@@ -1982,6 +1982,8 @@
     </include>
 
     <variable name="Items_ViewMode_Switch">
+        <value condition="String.IsEqual(Container.FolderPath,plugin://plugin.program.advanced.emulator.launcher/) | String.IsEqual(Container.FolderPath,plugin://plugin.program.advanced.emulator.launcher/?content_type=executable)">ael-launcher</value>
+        <value condition="String.StartsWith(Container.FolderPath,plugin://plugin.program.advanced.emulator.launcher/)">ael-rom</value>
         <value condition="String.IsEqual(Container.Content,genres) + Window.IsVisible(MyMusicNav.xml)">genres-music</value>
         <value condition="String.IsEqual(Container.Content,years) + Window.IsVisible(MyMusicNav.xml)">years-music</value>
         <value condition="!String.IsEmpty(Container.Content)">$INFO[Container.Content]</value>

--- a/shortcuts/skinviewtypes.json
+++ b/shortcuts/skinviewtypes.json
@@ -177,8 +177,18 @@
             "viewtypes": ["500", "54", "504", "52", "502", "51", "501"],
             "library": "500"
         },
+        "ael-launcher": {
+            "rule": "Container.Content() + [String.IsEqual(Container.FolderPath,plugin://plugin.program.advanced.emulator.launcher/) | String.IsEqual(Container.FolderPath,plugin://plugin.program.advanced.emulator.launcher/?content_type=executable)]",
+            "viewtypes": ["50", "500", "52", "55", "54", "57", "502", "501", "504"],
+            "plugins": "52"
+        },
+        "ael-rom": {
+            "rule": "Container.Content() + String.StartsWith(Container.FolderPath,plugin://plugin.program.advanced.emulator.launcher/) + ![String.IsEqual(Container.FolderPath,plugin://plugin.program.advanced.emulator.launcher/) | String.IsEqual(Container.FolderPath,plugin://plugin.program.advanced.emulator.launcher/?content_type=executable)]",
+            "viewtypes": ["50", "500", "52", "55", "54", "57", "502", "501", "504"],
+            "plugins": "50"
+        },
         "none": {
-            "rule": "Container.Content() + !Window.IsVisible(MyPVRTimers.xml) + !Window.IsVisible(MyPVRSearch.xml) + !Window.IsVisible(MyPVRRecordings.xml)",
+            "rule": "Container.Content() + !String.StartsWith(Container.FolderPath,plugin://plugin.program.advanced.emulator.launcher/) + !Window.IsVisible(MyPVRTimers.xml) + !Window.IsVisible(MyPVRSearch.xml) + !Window.IsVisible(MyPVRRecordings.xml)",
             "viewtypes": ["50", "500"],
             "library": "50",
             "plugins": "500"


### PR DESCRIPTION
Starting simple. Just enabling views for Advanced Emulator Launcher, nothing more. Only issue I had was that I could not test against the latest version in github because installation failed on this dependency in `addon.xml`:
`addon="plugin.video.themoviedb.helper" version="4.2.3"`

The latest version of this skin in the repo uses this version
`addon="plugin.video.themoviedb.helper" version="4.0.79"`