### PR TITLE
Add the channel number display to the PVR playlist

### DIFF
--- a/1080i/DialogPlayerProcessInfo.xml
+++ b/1080i/DialogPlayerProcessInfo.xml
@@ -31,6 +31,12 @@
                 <include content="Object_ShadowSpot_Label">
                     <param name="label" value="[COLOR panel_fg_100]$LOCALIZE[460]:[/COLOR] $INFO[Player.Process(audiochannels),,$COMMA ]$INFO[Player.Process(audiodecoder)]$INFO[Player.Process(audiobitspersample),$COMMA , bits]$INFO[Player.Process(audiosamplerate),$COMMA , Hz]" />
                 </include>
+                <include content="Object_ShadowSpot_Label" condition="System.HasAddon(service.coreelec.settings)">
+                    <param name="label" value="$INFO[Player.Process(amlogic.displaymode),[COLOR panel_fg_100]Display mode: [/COLOR] ]" />
+                </include>
+                <include content="Object_ShadowSpot_Label" condition="System.HasAddon(service.coreelec.settings)">
+					<param name="label" value="$INFO[Player.Process(amlogic.eoft_gamut),[COLOR panel_fg_100]EOTF & Gamut: [/COLOR] ]" />
+                </include>
             </include>
         </include>
 
@@ -60,6 +66,12 @@
                 </include>
                 <include content="Object_ShadowSpot_Label">
                     <param name="label" value="[COLOR panel_fg_100]$LOCALIZE[460]:[/COLOR] $INFO[Player.Process(audiochannels),,$COMMA ]$INFO[Player.Process(audiodecoder)]$INFO[Player.Process(audiobitspersample),$COMMA , bits]$INFO[Player.Process(audiosamplerate),$COMMA , Hz]" />
+                </include>
+                <include content="Object_ShadowSpot_Label" condition="System.HasAddon(service.coreelec.settings)">
+                    <param name="label" value="$INFO[Player.Process(amlogic.displaymode),[COLOR panel_fg_100]Display mode: [/COLOR] ]" />
+                </include>
+                <include content="Object_ShadowSpot_Label" condition="System.HasAddon(service.coreelec.settings)">
+					<param name="label" value="$INFO[Player.Process(amlogic.eoft_gamut),[COLOR panel_fg_100]EOTF & Gamut: [/COLOR] ]" />
                 </include>
                 <include content="Object_ShadowSpot_Label">
                     <param name="label" value="PVR Stream" />

--- a/1080i/DialogPlayerProcessInfo.xml
+++ b/1080i/DialogPlayerProcessInfo.xml
@@ -35,7 +35,7 @@
                     <param name="label" value="$INFO[Player.Process(amlogic.displaymode),[COLOR panel_fg_100]Display mode: [/COLOR] ]" />
                 </include>
                 <include content="Object_ShadowSpot_Label" condition="System.HasAddon(service.coreelec.settings)">
-					<param name="label" value="$INFO[Player.Process(amlogic.eoft_gamut),[COLOR panel_fg_100]EOTF & Gamut: [/COLOR] ]" />
+		    <param name="label" value="$INFO[Player.Process(amlogic.eoft_gamut),[COLOR panel_fg_100]EOTF & Gamut: [/COLOR] ]" />
                 </include>
             </include>
         </include>
@@ -71,7 +71,7 @@
                     <param name="label" value="$INFO[Player.Process(amlogic.displaymode),[COLOR panel_fg_100]Display mode: [/COLOR] ]" />
                 </include>
                 <include content="Object_ShadowSpot_Label" condition="System.HasAddon(service.coreelec.settings)">
-					<param name="label" value="$INFO[Player.Process(amlogic.eoft_gamut),[COLOR panel_fg_100]EOTF & Gamut: [/COLOR] ]" />
+		    <param name="label" value="$INFO[Player.Process(amlogic.eoft_gamut),[COLOR panel_fg_100]EOTF & Gamut: [/COLOR] ]" />
                 </include>
                 <include content="Object_ShadowSpot_Label">
                     <param name="label" value="PVR Stream" />

--- a/1080i/Includes_View_PVR.xml
+++ b/1080i/Includes_View_PVR.xml
@@ -179,18 +179,18 @@
                 <font>font_statusbar</font>
                 <label>$INFO[ListItem.ChannelName]</label>
             </control>
-            <control type="label">
-				<visible>Skin.HasSetting(PVRGuide.ChannelNumber)</visible>
-				<left>30</left>
-				<right>30</right>
-				<align>right</align>
-				<centertop>35%</centertop>
-				<height>40</height>
+	    <control type="label">
+		<visible>Skin.HasSetting(PVRGuide.ChannelNumber)</visible>
+		<left>30</left>
+		<right>30</right>
+		<align>right</align>
+		<centertop>35%</centertop>
+		<height>40</height>
                 <textcolor>$PARAM[fgcolor]</textcolor>
                 <selectedcolor>$PARAM[fgcolor]</selectedcolor>
-				<font>font_small_bold</font>
-				<label>$INFO[ListItem.ChannelNumberLabel]</label>
-			</control>
+		<font>font_small_bold</font>
+		<label>$INFO[ListItem.ChannelNumberLabel]</label>
+	    </control>
             <control type="label">
                 <left>30</left>
                 <right>30</right>

--- a/1080i/Includes_View_PVR.xml
+++ b/1080i/Includes_View_PVR.xml
@@ -180,6 +180,18 @@
                 <label>$INFO[ListItem.ChannelName]</label>
             </control>
             <control type="label">
+				<visible>Skin.HasSetting(PVRGuide.ChannelNumber)</visible>
+				<left>30</left>
+				<right>30</right>
+				<align>right</align>
+				<centertop>35%</centertop>
+				<height>40</height>
+                <textcolor>$PARAM[fgcolor]</textcolor>
+                <selectedcolor>$PARAM[fgcolor]</selectedcolor>
+				<font>font_small_bold</font>
+				<label>$INFO[ListItem.ChannelNumberLabel]</label>
+			</control>
+            <control type="label">
                 <left>30</left>
                 <right>30</right>
                 <align>right</align>


### PR DESCRIPTION
If the "Channel numbers" ( In the "Skin Settings - Live TV / PVR" ) has been set, the channel number will be displayed in PVR playlist.
![screenshot00001](https://user-images.githubusercontent.com/62541194/111705794-387d7380-887c-11eb-871b-e486ff927716.png)
