### PR TITLE
:art: - Fix "Watched Indicator" manual color entry

### DIFF
--- a/1080i/Custom_1117_ColorPicker.xml
+++ b/1080i/Custom_1117_ColorPicker.xml
@@ -240,7 +240,7 @@
                             <onclick condition="String.IsEqual(Window(Home).Property(colorpick),$LOCALIZE[31175])">Skin.SetString(focuscolor.name)</onclick>
                             <onclick condition="String.IsEqual(Window(Home).Property(colorpick),$LOCALIZE[31178])">Skin.SetString(gradientcolor.name)</onclick>
                             <onclick condition="String.IsEqual(Window(Home).Property(colorpick),$LOCALIZE[31179])">Skin.SetString(overlaycolor.name)</onclick>
-                            <onclick condition="String.IsEqual(Window(Home).Property(colorpick),$LOCALIZE[16102])">Skin.SetString(watchedprogress.name)</onclick>
+                            <onclick condition="String.IsEqual(Window(Home).Property(colorpick),$LOCALIZE[16102])">Skin.SetString(watchedprogresscolor.name)</onclick>
                         </control>
                         <!-- CHOOSE PALETTE -->
                         <control type="button" id="3030">

--- a/1080i/Custom_1121_EnableIndicators.xml
+++ b/1080i/Custom_1121_EnableIndicators.xml
@@ -40,7 +40,7 @@
                     <radioposx>730</radioposx>
                     <include>Dialog_Standard_Button</include>
                     <label2>$INFO[Skin.String(watchedprogresscolor.name)]</label2>
-                    <onclick>SetProperty(colorpick,Watched,Home)</onclick>
+                    <onclick>SetProperty(colorpick,$LOCALIZE[16102],Home)</onclick>
                     <onclick>ActivateWindow(1117)</onclick>
                     <enable>!Skin.HasSetting(EnableClassicIndicators) + !Skin.HasSetting(DisableWatchedOverlay)</enable>
                 </control>

--- a/1080i/Includes_Labels.xml
+++ b/1080i/Includes_Labels.xml
@@ -23,10 +23,10 @@
     </variable>
 
     <variable name="Label_ColorValue">
-        <value condition="String.IsEqual(Window(Home).Property(colorpick),Highlight) + !String.IsEmpty(Skin.String(focuscolor.name))">$INFO[Skin.String(focuscolor.name)]</value>
-        <value condition="String.IsEqual(Window(Home).Property(colorpick),Gradient) + !String.IsEmpty(Skin.String(gradientcolor.name))">$INFO[Skin.String(gradientcolor.name)]</value>
-        <value condition="String.IsEqual(Window(Home).Property(colorpick),Overlay) + !String.IsEmpty(Skin.String(overlaycolor.name))">$INFO[Skin.String(overlaycolor.name)]</value>
-        <value condition="String.IsEqual(Window(Home).Property(colorpick),Watched) + !String.IsEmpty(Skin.String(watchedprogresscolor.name))">$INFO[Skin.String(watchedprogresscolor.name)]</value>
+        <value condition="String.IsEqual(Window(Home).Property(colorpick),$LOCALIZE[31175]) + !String.IsEmpty(Skin.String(focuscolor.name))">$INFO[Skin.String(focuscolor.name)]</value>
+        <value condition="String.IsEqual(Window(Home).Property(colorpick),$LOCALIZE[31178]) + !String.IsEmpty(Skin.String(gradientcolor.name))">$INFO[Skin.String(gradientcolor.name)]</value>
+        <value condition="String.IsEqual(Window(Home).Property(colorpick),$LOCALIZE[31179]) + !String.IsEmpty(Skin.String(overlaycolor.name))">$INFO[Skin.String(overlaycolor.name)]</value>
+        <value condition="String.IsEqual(Window(Home).Property(colorpick),$LOCALIZE[16102]) + !String.IsEmpty(Skin.String(watchedprogresscolor.name))">$INFO[Skin.String(watchedprogresscolor.name)]</value>
         <value>$LOCALIZE[571]</value>
     </variable>
 


### PR DESCRIPTION
Fixes the manual color entry box for watched indicators, as it is not working per #428. There are a couple other things mentioned in that issue, but this closes the main issue.

You can now successfully enter a color code manually, or clear the entry to return to defaults.